### PR TITLE
chore(doc): fixing typo in farewell-workflow README.md file

### DIFF
--- a/exercises/farewell-workflow/README.md
+++ b/exercises/farewell-workflow/README.md
@@ -38,8 +38,8 @@ All commands below must be run from the `practice` subdirectory.
 
 1. Install your dependencies with `npm install` in a terminal
 1. Start the microservice by running `npm run service.watch`
-1. In another terminal, start your Worker by running `npm run start.watch`
-1. In a third terminal, change into the `exercises/farewell-workflow/practice` subdirectory and execute your Workflow by running `npm start workflow` (replacing `Tina` with your own name)
+1. In another terminal, start your Worker by running `npm run worker.watch`
+1. In a third terminal, change into the `exercises/farewell-workflow/practice` subdirectory and execute your Workflow by running `npm run farewell` (replacing `Tina` with your own name)
 
 If there is time remaining, experiment with Activity failures and retries 
 by stopping the microservice (press Ctrl-C in its terminal) and re-running 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
I basically updated the `README.md` file to align `farewell-workflow` instructions with the script definition. 

## Why?
<!-- Tell your future self why have you made these changes -->
While completing the course, I've noticed the documentation of `farewell-workflow` is not aligned with the scripts being defined in the related `package.json` file so I suggest updating it. 
See related error: 
```
❯ npm run start.watch  
npm ERR! Missing script: "start.watch"
npm ERR! 
npm ERR! To see a list of scripts, run:
npm ERR!   npm run
```
We can either update the script definition or the documentation (as I've just done in this branch). 

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
None 

3. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
It was while completing the course.

4. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
None more than the updated one.
