### PR TITLE
corrected the spelling of Adiós (was missing the accent mark)

### DIFF
--- a/demos/service-workflow/src/service.ts
+++ b/demos/service-workflow/src/service.ts
@@ -36,7 +36,7 @@ app.use('/get-spanish-farewell', (req: Request, res: Response) => {
 
   const name = req.query.name;
   res.status(200);
-  res.send(`¡Adios, ${name}!`);
+  res.send(`¡Adiós, ${name}!`);
 });
 
 app.use(notFound);

--- a/exercises/farewell-workflow/practice/src/service.ts
+++ b/exercises/farewell-workflow/practice/src/service.ts
@@ -36,7 +36,7 @@ app.use('/get-spanish-farewell', (req: Request, res: Response) => {
 
   const name = req.query.name;
   res.status(200);
-  res.send(`¡Adios, ${name}!`);
+  res.send(`¡Adiós, ${name}!`);
 });
 
 app.use(notFound);

--- a/exercises/farewell-workflow/solution/src/service.ts
+++ b/exercises/farewell-workflow/solution/src/service.ts
@@ -36,7 +36,7 @@ app.use('/get-spanish-farewell', (req: Request, res: Response) => {
 
   const name = req.query.name;
   res.status(200);
-  res.send(`¡Adios, ${name}!`);
+  res.send(`¡Adiós, ${name}!`);
 });
 
 app.use(notFound);


### PR DESCRIPTION
## What was changed
While working on the Java version of the Temporal 101 course, I noticed that the accent mark was missing in the word Adiós. This PR corrects all such occurrences (I have already made the same change to the corresponding code for Go and Java).

## Why?
The word was misspelled, possible due to a character encoding issue when I was developing the original Go version of the course (which I have since corrected).

## Checklist

1. How was this tested:

In the two exercises and one demo where I made this change, I started the service and invoked it using an HTTP client, verifying that the service started as expected, accepted the request, and returned the correct spelling in the response.

2. Any docs updates needed?

No
