### PR TITLE
fix dark mode not showing fonts clearly

### DIFF
--- a/style.css
+++ b/style.css
@@ -99,6 +99,7 @@
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
   margin: 0;
+  padding: 1em;
   color: var(--color-fg-default);
   background-color: var(--color-canvas-default);
   font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
@@ -213,6 +214,7 @@
 .markdown-body samp {
   font-family: monospace,monospace;
   font-size: 1em;
+  color: var(--color-fg-default);
 }
 
 .markdown-body figure {


### PR DESCRIPTION
Fix code fonts so dark mode is more readable and uses the correct foreground variable.
Add padding around content area so text doesn't sit against the edge.