### PR TITLE
Update versions in package.json

### DIFF
--- a/exercises/finale-workflow/package.json
+++ b/exercises/finale-workflow/package.json
@@ -21,10 +21,10 @@
     ]
   },
   "dependencies": {
-    "@temporalio/activity": "~1.8.0",
-    "@temporalio/client": "~1.8.0",
-    "@temporalio/worker": "~1.8.0",
-    "@temporalio/workflow": "~1.8.0",
+    "@temporalio/activity": "~1.9.0",
+    "@temporalio/client": "~1.9.0",
+    "@temporalio/worker": "~1.9.0",
+    "@temporalio/workflow": "~1.9.0",
     "nanoid": "3.x"
   },
   "devDependencies": {


### PR DESCRIPTION
## What was changed
Updated version numbers of temporalio-related items in the dependencies section from 1.8.0 to 1.9.0.

## Why?
This resolves an `ERR_PACKAGE_PATH_NOT_EXPORTED` error from `node_modules/@temporalio/worker/src/tracing.ts` that occurs during this exercise with the previous versions.

## Checklist
1. Closes EDU-2144

2. How was this tested:
I reproduced it in a new GitPod workspace, then applied the film, and verified that I could complete the exercise without error (Drew Gorton also verified the fix in a local exercise environment).

3. Any docs updates needed?
No
