### PR TITLE
Change workflow id parameter used in `temporal workflow show`

### DIFF
--- a/exercises/hello-workflow/README.md
+++ b/exercises/hello-workflow/README.md
@@ -77,7 +77,7 @@ If you have time, continue with the optional part of the exercise below to see h
 You can run the following command to display the result of a Workflow Execution: 
 
 ```command
-temporal workflow show --workflow_id <your_workflow_id>
+temporal workflow show --workflow-id <your_workflow_id>
 ```
 This command shows you a lot of information. We will cover this output later in the course. 
 


### PR DESCRIPTION
It's a dash, not an underscore.

## What was changed
Updating the README.md with the correct parameter. See the [docs](https://docs.temporal.io/cli/cmd-options#workflow-id) for reference.

## Why?
<!-- Tell your future self why have you made these changes -->
So the README will give the correct instructions.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
There's no open issue. I can add one.

3. How was this tested:
I ran through the temporal 101 course and failed with the current command, succeeded with the updated one.

4. Any docs updates needed?
I did 🙂 