### PR TITLE
Fix queue name ref in comment

### DIFF
--- a/exercises/hello-workflow/practice/src/worker.ts
+++ b/exercises/hello-workflow/practice/src/worker.ts
@@ -18,7 +18,7 @@ async function run() {
     workflowsPath: require.resolve('./workflows'),
   });
 
-  // Step 3: Start accepting tasks on the `greeting-tasks` queue
+  // Step 3: Start accepting tasks on the `hello-world` queue
   //
   // The worker runs until it encounters an unexepected error or the process receives a shutdown signal registered on
   // the SDK Runtime object.


### PR DESCRIPTION

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Changed queue mentioned in Step 3 comment

## Why?
The Step 3 comment says the code will start accepting tasks in the "`greeting-tasks` queue", but in the code above the configured queue is "hello-world.

## Checklist
N/A, no ticket and no test since its just an comment update